### PR TITLE
Wave 2 Phase 2: ZETA - Git Publish with Privacy Filtering

### DIFF
--- a/writer/src-tauri/Cargo.lock
+++ b/writer/src-tauri/Cargo.lock
@@ -432,6 +432,7 @@ dependencies = [
  "dirs 5.0.1",
  "dotenv",
  "futures-util",
+ "git2",
  "hf-hub",
  "hound",
  "keyring",
@@ -2118,6 +2119,21 @@ dependencies = [
 ]
 
 [[package]]
+name = "git2"
+version = "0.19.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b903b73e45dc0c6c596f2d37eccece7c1c8bb6e4407b001096387c63d0d93724"
+dependencies = [
+ "bitflags 2.10.0",
+ "libc",
+ "libgit2-sys",
+ "log",
+ "openssl-probe",
+ "openssl-sys",
+ "url",
+]
+
+[[package]]
 name = "glib"
 version = "0.18.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2927,6 +2943,20 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2874a2af47a2325c2001a6e6fad9b16a53b802102b528163885171cf92b15976"
 
 [[package]]
+name = "libgit2-sys"
+version = "0.17.0+1.8.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "10472326a8a6477c3c20a64547b0059e4b0d086869eee31e6d7da728a8eb7224"
+dependencies = [
+ "cc",
+ "libc",
+ "libssh2-sys",
+ "libz-sys",
+ "openssl-sys",
+ "pkg-config",
+]
+
+[[package]]
 name = "libloading"
 version = "0.7.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2969,6 +2999,32 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2e99fb7a497b1e3339bc746195567ed8d3e24945ecd636e3619d20b9de9e9149"
 dependencies = [
  "cc",
+ "pkg-config",
+ "vcpkg",
+]
+
+[[package]]
+name = "libssh2-sys"
+version = "0.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "220e4f05ad4a218192533b300327f5150e809b54c4ec83b5a1d91833601811b9"
+dependencies = [
+ "cc",
+ "libc",
+ "libz-sys",
+ "openssl-sys",
+ "pkg-config",
+ "vcpkg",
+]
+
+[[package]]
+name = "libz-sys"
+version = "1.1.23"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "15d118bbf3771060e7311cc7bb0545b01d08a8b4a7de949198dec1fa0ca1c0f7"
+dependencies = [
+ "cc",
+ "libc",
  "pkg-config",
  "vcpkg",
 ]

--- a/writer/src-tauri/Cargo.toml
+++ b/writer/src-tauri/Cargo.toml
@@ -31,6 +31,7 @@ reqwest = { version = "0.12", features = ["json", "stream"] }
 futures-util = "0.3"
 keyring = "2.3"
 dotenv = "0.15"
+git2 = "0.19"
 
 [build-dependencies]
 tauri-build = { version = "2.5", features = [] }

--- a/writer/src-tauri/src/error.rs
+++ b/writer/src-tauri/src/error.rs
@@ -19,6 +19,8 @@ pub enum BrainDumpError {
     OpenAiApi(OpenAiApiError),
     /// Prompt template errors
     Prompt(PromptError),
+    /// Git publish errors
+    Git(GitError),
     /// File I/O errors (serialized as string)
     Io(String),
     /// Generic errors with context
@@ -145,6 +147,23 @@ pub enum PromptError {
     InvalidTemplate(String),
 }
 
+/// Git publish errors
+#[derive(Debug, Serialize)]
+pub enum GitError {
+    /// Git operation failed
+    GitOperationFailed(String),
+    /// Repository not found
+    RepositoryNotFound(String),
+    /// No publishable cards found
+    NoPublishableCards,
+    /// IO error
+    IoError(String),
+    /// Git library error
+    Git2Error(String),
+    /// Database error
+    DatabaseError(String),
+}
+
 // Implement Display trait for user-facing messages
 impl fmt::Display for BrainDumpError {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
@@ -155,6 +174,7 @@ impl fmt::Display for BrainDumpError {
             BrainDumpError::ClaudeApi(e) => write!(f, "Claude API Error: {}", e),
             BrainDumpError::OpenAiApi(e) => write!(f, "OpenAI API Error: {}", e),
             BrainDumpError::Prompt(e) => write!(f, "Prompt Error: {}", e),
+            BrainDumpError::Git(e) => write!(f, "Git Error: {}", e),
             BrainDumpError::Io(e) => write!(f, "File Error: {}", e),
             BrainDumpError::Other(msg) => write!(f, "{}", msg),
         }
@@ -381,6 +401,31 @@ impl fmt::Display for PromptError {
     }
 }
 
+impl fmt::Display for GitError {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        match self {
+            GitError::GitOperationFailed(msg) => {
+                write!(f, "Git operation failed: {}", msg)
+            }
+            GitError::RepositoryNotFound(path) => {
+                write!(f, "Git repository not found at: {}", path)
+            }
+            GitError::NoPublishableCards => {
+                write!(f, "No publishable cards found. Only BUSINESS and IDEAS cards can be published")
+            }
+            GitError::IoError(msg) => {
+                write!(f, "File error: {}", msg)
+            }
+            GitError::Git2Error(msg) => {
+                write!(f, "Git error: {}", msg)
+            }
+            GitError::DatabaseError(msg) => {
+                write!(f, "Database error: {}", msg)
+            }
+        }
+    }
+}
+
 // Implement std::error::Error trait
 impl std::error::Error for BrainDumpError {}
 impl std::error::Error for AudioError {}
@@ -389,6 +434,7 @@ impl std::error::Error for TranscriptionError {}
 impl std::error::Error for ClaudeApiError {}
 impl std::error::Error for OpenAiApiError {}
 impl std::error::Error for PromptError {}
+impl std::error::Error for GitError {}
 
 // Conversions from specific errors to BrainDumpError
 impl From<AudioError> for BrainDumpError {
@@ -424,6 +470,12 @@ impl From<OpenAiApiError> for BrainDumpError {
 impl From<PromptError> for BrainDumpError {
     fn from(err: PromptError) -> Self {
         BrainDumpError::Prompt(err)
+    }
+}
+
+impl From<GitError> for BrainDumpError {
+    fn from(err: GitError) -> Self {
+        BrainDumpError::Git(err)
     }
 }
 

--- a/writer/src-tauri/src/git/mod.rs
+++ b/writer/src-tauri/src/git/mod.rs
@@ -1,0 +1,406 @@
+//! Git publish module - selective sync of BUSINESS + IDEAS cards only
+//!
+//! Privacy Rules:
+//! - PRIVATE: NEVER sync (stays local only)
+//! - PERSONAL: NEVER sync (stays local only)
+//! - BUSINESS: Sync to GitHub
+//! - IDEAS: Sync to GitHub
+
+use crate::db::models::{Card, PrivacyLevel};
+use crate::db::repository::Repository;
+use crate::error::GitError;
+use chrono::Utc;
+use git2::{Commit, Cred, Repository as GitRepository, Signature};
+use serde::{Deserialize, Serialize};
+use std::fs;
+use std::path::{Path, PathBuf};
+
+// Implement conversions for git module specific errors
+impl From<std::io::Error> for GitError {
+    fn from(err: std::io::Error) -> Self {
+        GitError::IoError(err.to_string())
+    }
+}
+
+impl From<git2::Error> for GitError {
+    fn from(err: git2::Error) -> Self {
+        GitError::Git2Error(err.to_string())
+    }
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct PublishResult {
+    pub cards_published: usize,
+    pub commit_sha: String,
+    pub pushed: bool,
+    pub timestamp: String,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct PublishStatus {
+    pub publishable_count: usize,
+    pub published_count: usize,
+    pub last_publish_at: Option<String>,
+    pub last_commit_sha: Option<String>,
+}
+
+/// Git publisher for cards
+pub struct GitPublisher {
+    repo_path: PathBuf,
+    content_dir: PathBuf,
+}
+
+impl GitPublisher {
+    /// Create a new Git publisher
+    pub fn new(repo_path: impl Into<PathBuf>) -> Self {
+        let repo_path = repo_path.into();
+        let content_dir = repo_path.join("content");
+
+        Self {
+            repo_path,
+            content_dir,
+        }
+    }
+
+    /// Initialize the Git repository if it doesn't exist
+    pub fn initialize_repository(&self) -> Result<(), GitError> {
+        // Check if repo already exists
+        if self.repo_path.join(".git").exists() {
+            return Ok(());
+        }
+
+        // Initialize new repository
+        GitRepository::init(&self.repo_path)?;
+
+        // Create content directory
+        fs::create_dir_all(&self.content_dir)?;
+
+        // Create .gitignore
+        let gitignore_path = self.repo_path.join(".gitignore");
+        fs::write(gitignore_path, "# BrainDump Published Content\n\n# Ignore system files\n.DS_Store\nThumbs.db\n")?;
+
+        // Create initial README
+        let readme_path = self.repo_path.join("README.md");
+        fs::write(
+            readme_path,
+            "# BrainDump Published Content\n\nThis repository contains published cards from BrainDump.\n\n**Privacy Levels Published:**\n- BUSINESS: Work-related content\n- IDEAS: Public-safe ideas and concepts\n\n**Privacy Levels NOT Published:**\n- PRIVATE: Contains PII (SSN, email, credit cards)\n- PERSONAL: Personal references (\"I feel\", family)\n",
+        )?;
+
+        // Initial commit
+        let repo = GitRepository::open(&self.repo_path)?;
+        let mut index = repo.index()?;
+        index.add_path(Path::new(".gitignore"))?;
+        index.add_path(Path::new("README.md"))?;
+        index.write()?;
+
+        let tree_id = index.write_tree()?;
+        let tree = repo.find_tree(tree_id)?;
+        let signature = Signature::now("BrainDump", "braindump@local")?;
+
+        repo.commit(
+            Some("HEAD"),
+            &signature,
+            &signature,
+            "Initial commit - BrainDump content repository",
+            &tree,
+            &[],
+        )?;
+
+        Ok(())
+    }
+
+    /// Filter cards by privacy level (BUSINESS + IDEAS only)
+    pub fn filter_publishable_cards(&self, cards: &[Card]) -> Vec<Card> {
+        cards
+            .iter()
+            .filter(|card| {
+                matches!(
+                    card.privacy_level,
+                    Some(PrivacyLevel::Business) | Some(PrivacyLevel::Ideas)
+                )
+            })
+            .cloned()
+            .collect()
+    }
+
+    /// Export card to markdown file
+    pub fn export_card_to_markdown(&self, card: &Card) -> Result<PathBuf, GitError> {
+        // Ensure content directory exists
+        fs::create_dir_all(&self.content_dir)?;
+
+        // Generate filename from card ID
+        let card_id = card
+            .id
+            .ok_or_else(|| GitError::GitOperationFailed("Card has no ID".to_string()))?;
+        let filename = format!("card-{}.md", card_id);
+        let filepath = self.content_dir.join(&filename);
+
+        // Create markdown content
+        let privacy_level = card
+            .privacy_level
+            .as_ref()
+            .map(|p| p.as_str())
+            .unwrap_or("UNKNOWN");
+        let category = card
+            .category
+            .as_ref()
+            .map(|c| c.as_str())
+            .unwrap_or("UNCATEGORIZED");
+
+        let markdown = format!(
+            "---\nid: {}\nprivacy: {}\ncategory: {}\ncreated: {}\nupdated: {}\n---\n\n# Card {}\n\n{}\n",
+            card_id,
+            privacy_level,
+            category,
+            card.created_at.format("%Y-%m-%d %H:%M:%S"),
+            card.updated_at.format("%Y-%m-%d %H:%M:%S"),
+            card_id,
+            card.content
+        );
+
+        // Write to file
+        fs::write(&filepath, markdown)?;
+
+        Ok(filepath)
+    }
+
+    /// Export all publishable cards to markdown files
+    pub fn export_all_publishable_cards(&self, cards: &[Card]) -> Result<Vec<PathBuf>, GitError> {
+        let publishable = self.filter_publishable_cards(cards);
+
+        if publishable.is_empty() {
+            return Err(GitError::NoPublishableCards);
+        }
+
+        let mut exported_files = Vec::new();
+        for card in publishable {
+            let filepath = self.export_card_to_markdown(&card)?;
+            exported_files.push(filepath);
+        }
+
+        Ok(exported_files)
+    }
+
+    /// Git add files to staging area
+    pub fn git_add(&self, files: &[PathBuf]) -> Result<(), GitError> {
+        let repo = GitRepository::open(&self.repo_path)?;
+        let mut index = repo.index()?;
+
+        for file in files {
+            // Get relative path from repo root
+            let relative_path = file
+                .strip_prefix(&self.repo_path)
+                .map_err(|e| GitError::GitOperationFailed(format!("Invalid file path: {}", e)))?;
+            index.add_path(relative_path)?;
+        }
+
+        index.write()?;
+        Ok(())
+    }
+
+    /// Git commit with message
+    pub fn git_commit(&self, message: &str) -> Result<String, GitError> {
+        let repo = GitRepository::open(&self.repo_path)?;
+        let mut index = repo.index()?;
+        let tree_id = index.write_tree()?;
+        let tree = repo.find_tree(tree_id)?;
+
+        let signature = Signature::now("BrainDump", "braindump@local")?;
+
+        // Get parent commit
+        let parent_commit = self.get_head_commit(&repo)?;
+
+        let commit_id = repo.commit(
+            Some("HEAD"),
+            &signature,
+            &signature,
+            message,
+            &tree,
+            &[&parent_commit],
+        )?;
+
+        Ok(commit_id.to_string())
+    }
+
+    /// Get HEAD commit
+    fn get_head_commit<'repo>(&self, repo: &'repo GitRepository) -> Result<Commit<'repo>, GitError> {
+        let head = repo.head()?;
+        let commit = head.peel_to_commit()?;
+        Ok(commit)
+    }
+
+    /// Git push to remote
+    pub fn git_push(&self, remote_name: &str, branch: &str) -> Result<(), GitError> {
+        let repo = GitRepository::open(&self.repo_path)?;
+
+        // Get remote
+        let mut remote = repo
+            .find_remote(remote_name)
+            .map_err(|e| GitError::GitOperationFailed(format!("Remote '{}' not found: {}", remote_name, e)))?;
+
+        // Setup callbacks for authentication
+        let mut callbacks = RemoteCallbacks::new();
+        callbacks.credentials(|_url, username_from_url, _allowed_types| {
+            Cred::ssh_key_from_agent(username_from_url.unwrap_or("git"))
+        });
+
+        let mut push_options = PushOptions::new();
+        push_options.remote_callbacks(callbacks);
+
+        // Push
+        let refspec = format!("refs/heads/{}:refs/heads/{}", branch, branch);
+        remote.push(&[&refspec], Some(&mut push_options))?;
+
+        Ok(())
+    }
+
+    /// Publish cards: export, commit, and optionally push
+    pub fn publish_cards(
+        &self,
+        cards: &[Card],
+        commit_message: &str,
+        should_push: bool,
+        remote_name: &str,
+        branch: &str,
+    ) -> Result<PublishResult, GitError> {
+        // Filter and export publishable cards
+        let exported_files = self.export_all_publishable_cards(cards)?;
+        let cards_published = exported_files.len();
+
+        // Git add
+        self.git_add(&exported_files)?;
+
+        // Git commit
+        let commit_sha = self.git_commit(commit_message)?;
+
+        // Git push (optional)
+        let pushed = if should_push {
+            match self.git_push(remote_name, branch) {
+                Ok(_) => true,
+                Err(e) => {
+                    eprintln!("Warning: Failed to push: {}", e);
+                    false
+                }
+            }
+        } else {
+            false
+        };
+
+        Ok(PublishResult {
+            cards_published,
+            commit_sha,
+            pushed,
+            timestamp: Utc::now().to_rfc3339(),
+        })
+    }
+
+    /// Get publish status
+    pub fn get_status(&self, repository: &Repository) -> Result<PublishStatus, GitError> {
+        // Get publishable cards count
+        let publishable_cards = repository
+            .get_publishable_cards(1000)
+            .map_err(|e| GitError::DatabaseError(e.to_string()))?;
+        let publishable_count = publishable_cards.len();
+
+        // Count already published cards
+        let published_count = publishable_cards.iter().filter(|c| c.published).count();
+
+        // Get last commit info if repo exists
+        let (last_commit_sha, last_publish_at) = if self.repo_path.join(".git").exists() {
+            match GitRepository::open(&self.repo_path) {
+                Ok(repo) => match self.get_head_commit(&repo) {
+                    Ok(commit) => {
+                        let sha = commit.id().to_string();
+                        let time = commit.time();
+                        let timestamp = chrono::DateTime::from_timestamp(time.seconds(), 0)
+                            .map(|dt| dt.to_rfc3339());
+                        (Some(sha), timestamp)
+                    }
+                    Err(_) => (None, None),
+                },
+                Err(_) => (None, None),
+            }
+        } else {
+            (None, None)
+        };
+
+        Ok(PublishStatus {
+            publishable_count,
+            published_count,
+            last_publish_at,
+            last_commit_sha,
+        })
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::db::models::CardCategory;
+    use chrono::Utc;
+    use tempfile::TempDir;
+
+    fn create_test_card(id: i64, privacy_level: PrivacyLevel, content: &str) -> Card {
+        Card {
+            id: Some(id),
+            content: content.to_string(),
+            privacy_level: Some(privacy_level),
+            published: false,
+            git_sha: None,
+            category: Some(CardCategory::Ideas),
+            session_id: None,
+            message_id: None,
+            created_at: Utc::now(),
+            updated_at: Utc::now(),
+        }
+    }
+
+    #[test]
+    fn test_filter_publishable_cards() {
+        let temp_dir = TempDir::new().unwrap();
+        let publisher = GitPublisher::new(temp_dir.path());
+
+        let cards = vec![
+            create_test_card(1, PrivacyLevel::Private, "Private content with SSN"),
+            create_test_card(2, PrivacyLevel::Personal, "Personal: I feel sad"),
+            create_test_card(3, PrivacyLevel::Business, "Client meeting notes"),
+            create_test_card(4, PrivacyLevel::Ideas, "New product idea"),
+        ];
+
+        let publishable = publisher.filter_publishable_cards(&cards);
+
+        assert_eq!(publishable.len(), 2);
+        assert_eq!(publishable[0].id, Some(3));
+        assert_eq!(publishable[1].id, Some(4));
+    }
+
+    #[test]
+    fn test_export_card_to_markdown() {
+        let temp_dir = TempDir::new().unwrap();
+        let publisher = GitPublisher::new(temp_dir.path());
+
+        let card = create_test_card(42, PrivacyLevel::Business, "Test business content");
+
+        let filepath = publisher.export_card_to_markdown(&card).unwrap();
+
+        assert!(filepath.exists());
+        assert_eq!(filepath.file_name().unwrap(), "card-42.md");
+
+        let content = fs::read_to_string(&filepath).unwrap();
+        assert!(content.contains("privacy: BUSINESS"));
+        assert!(content.contains("Test business content"));
+    }
+
+    #[test]
+    fn test_initialize_repository() {
+        let temp_dir = TempDir::new().unwrap();
+        let publisher = GitPublisher::new(temp_dir.path());
+
+        publisher.initialize_repository().unwrap();
+
+        assert!(temp_dir.path().join(".git").exists());
+        assert!(temp_dir.path().join("content").exists());
+        assert!(temp_dir.path().join(".gitignore").exists());
+        assert!(temp_dir.path().join("README.md").exists());
+    }
+}

--- a/writer/src-tauri/src/lib.rs
+++ b/writer/src-tauri/src/lib.rs
@@ -13,6 +13,7 @@ pub mod backup;
 pub mod db;
 pub mod error;
 pub mod export;
+pub mod git;
 pub mod logging;
 pub mod plugin;
 pub mod prompts;
@@ -21,8 +22,10 @@ pub mod services;
 pub use audio::{Recorder, RecorderError, RecorderResult, WavWriter};
 pub use db::{initialize_db, models, repository, Recording, Repository, Segment, Transcript};
 pub use error::{
-    AudioError, BrainDumpError, ClaudeApiError, DatabaseError, OpenAiApiError, TranscriptionError,
+    AudioError, BrainDumpError, ClaudeApiError, DatabaseError, GitError, OpenAiApiError,
+    TranscriptionError,
 };
+pub use git::{GitPublisher, PublishResult, PublishStatus};
 pub use plugin::{
     AudioData, PluginError, Transcript as PluginTranscript, TranscriptSegment, TranscriptionPlugin,
 };

--- a/writer/src-tauri/src/main.rs
+++ b/writer/src-tauri/src/main.rs
@@ -462,6 +462,11 @@ fn main() {
             // Language Preference Commands (Issue #12)
             commands::get_language_preference,
             commands::set_language_preference,
+            // Git Publish Commands (Wave 2 - ZETA)
+            commands::git_init_repository,
+            commands::git_get_publish_status,
+            commands::git_publish_cards,
+            commands::git_get_publishable_count,
             // Model Manager Commands
             services::model_manager::get_available_models,
             services::model_manager::get_installed_models,

--- a/writer/src/islands/PublishIsland.svelte
+++ b/writer/src/islands/PublishIsland.svelte
@@ -1,0 +1,562 @@
+<script lang="ts">
+  /**
+   * Git Publish Island - One-click sync for BUSINESS + IDEAS cards
+   * Privacy Filter: PRIVATE and PERSONAL cards stay local only
+   */
+  import { invoke } from '@tauri-apps/api/core';
+  import { homeDir } from '@tauri-apps/api/path';
+
+  // Props
+  let {
+    onPublishComplete = null,
+  }: {
+    onPublishComplete?: (() => void) | null;
+  } = $props();
+
+  // State
+  let repoPath = $state<string>('');
+  let publishableCount = $state<number>(0);
+  let publishedCount = $state<number>(0);
+  let lastPublishAt = $state<string | null>(null);
+  let lastCommitSha = $state<string | null>(null);
+  let isPublishing = $state<boolean>(false);
+  let isLoading = $state<boolean>(false);
+  let error = $state<string | null>(null);
+  let commitMessage = $state<string>('Update published cards');
+  let shouldPush = $state<boolean>(false);
+  let remoteName = $state<string>('origin');
+  let branch = $state<string>('main');
+
+  interface PublishStatus {
+    publishable_count: number;
+    published_count: number;
+    last_publish_at: string | null;
+    last_commit_sha: string | null;
+  }
+
+  interface PublishResult {
+    cards_published: number;
+    commit_sha: string;
+    pushed: boolean;
+    timestamp: string;
+  }
+
+  /**
+   * Load initial repo path
+   */
+  async function loadRepoPath() {
+    try {
+      const home = await homeDir();
+      repoPath = `${home}.braindump-publish`;
+    } catch (err) {
+      console.error('Failed to get home directory:', err);
+      repoPath = '';
+    }
+  }
+
+  /**
+   * Initialize repository
+   */
+  async function initializeRepository() {
+    if (!repoPath) {
+      error = 'Please set a repository path';
+      return;
+    }
+
+    isLoading = true;
+    error = null;
+
+    try {
+      await invoke('git_init_repository', { repoPath });
+      await loadStatus();
+    } catch (err) {
+      error = `Failed to initialize repository: ${err}`;
+      console.error('Initialize error:', err);
+    } finally {
+      isLoading = false;
+    }
+  }
+
+  /**
+   * Load publish status
+   */
+  async function loadStatus() {
+    if (!repoPath) return;
+
+    isLoading = true;
+    error = null;
+
+    try {
+      const status = await invoke<PublishStatus>('git_get_publish_status', {
+        repoPath,
+      });
+
+      publishableCount = status.publishable_count;
+      publishedCount = status.published_count;
+      lastPublishAt = status.last_publish_at;
+      lastCommitSha = status.last_commit_sha;
+    } catch (err) {
+      error = `Failed to load status: ${err}`;
+      console.error('Load status error:', err);
+    } finally {
+      isLoading = false;
+    }
+  }
+
+  /**
+   * Publish cards to Git
+   */
+  async function publishCards() {
+    if (!repoPath) {
+      error = 'Please set a repository path';
+      return;
+    }
+
+    if (publishableCount === 0) {
+      error = 'No publishable cards found';
+      return;
+    }
+
+    isPublishing = true;
+    error = null;
+
+    try {
+      const result = await invoke<PublishResult>('git_publish_cards', {
+        repoPath,
+        commitMessage,
+        shouldPush,
+        remoteName,
+        branch,
+      });
+
+      // Update status
+      lastCommitSha = result.commit_sha;
+      lastPublishAt = result.timestamp;
+
+      // Show success
+      if (result.pushed) {
+        error = null;
+        console.log(`Published ${result.cards_published} cards and pushed to remote`);
+      } else {
+        error = null;
+        console.log(`Published ${result.cards_published} cards (not pushed)`);
+      }
+
+      // Reload status
+      await loadStatus();
+
+      // Call callback
+      if (onPublishComplete) {
+        onPublishComplete();
+      }
+    } catch (err) {
+      error = `Failed to publish: ${err}`;
+      console.error('Publish error:', err);
+    } finally {
+      isPublishing = false;
+    }
+  }
+
+  /**
+   * Format timestamp
+   */
+  function formatTimestamp(timestamp: string | null): string {
+    if (!timestamp) return 'Never';
+
+    try {
+      const date = new Date(timestamp);
+      return date.toLocaleString();
+    } catch {
+      return 'Invalid date';
+    }
+  }
+
+  /**
+   * Truncate commit SHA
+   */
+  function truncateSha(sha: string | null): string {
+    if (!sha) return 'N/A';
+    return sha.substring(0, 8);
+  }
+
+  // Load on mount
+  $effect(() => {
+    loadRepoPath();
+  });
+
+  // Auto-load status when repo path changes
+  $effect(() => {
+    if (repoPath) {
+      loadStatus();
+    }
+  });
+</script>
+
+<div class="publish-island">
+  <div class="header">
+    <h2>Git Publish</h2>
+    <p class="subtitle">Sync BUSINESS + IDEAS cards (PRIVATE/PERSONAL stay local)</p>
+  </div>
+
+  <!-- Configuration -->
+  <div class="config-section">
+    <div class="form-group">
+      <label for="repo-path">Repository Path</label>
+      <div class="input-with-button">
+        <input
+          id="repo-path"
+          type="text"
+          bind:value={repoPath}
+          placeholder="e.g., /Users/you/.braindump-publish"
+          disabled={isPublishing || isLoading}
+        />
+        <button
+          type="button"
+          onclick={initializeRepository}
+          disabled={isPublishing || isLoading || !repoPath}
+          class="btn-secondary"
+        >
+          {#if isLoading}
+            Initializing...
+          {:else}
+            Init Repo
+          {/if}
+        </button>
+      </div>
+    </div>
+  </div>
+
+  <!-- Status Display -->
+  <div class="status-section">
+    <div class="status-grid">
+      <div class="status-item">
+        <span class="status-label">Publishable Cards</span>
+        <span class="status-value">{publishableCount}</span>
+      </div>
+      <div class="status-item">
+        <span class="status-label">Published Cards</span>
+        <span class="status-value">{publishedCount}</span>
+      </div>
+      <div class="status-item">
+        <span class="status-label">Last Publish</span>
+        <span class="status-value">{formatTimestamp(lastPublishAt)}</span>
+      </div>
+      <div class="status-item">
+        <span class="status-label">Commit SHA</span>
+        <span class="status-value">{truncateSha(lastCommitSha)}</span>
+      </div>
+    </div>
+  </div>
+
+  <!-- Publish Options -->
+  <div class="options-section">
+    <div class="form-group">
+      <label for="commit-message">Commit Message</label>
+      <input
+        id="commit-message"
+        type="text"
+        bind:value={commitMessage}
+        placeholder="Update published cards"
+        disabled={isPublishing || isLoading}
+      />
+    </div>
+
+    <div class="checkbox-group">
+      <label>
+        <input
+          type="checkbox"
+          bind:checked={shouldPush}
+          disabled={isPublishing || isLoading}
+        />
+        <span>Push to remote</span>
+      </label>
+    </div>
+
+    {#if shouldPush}
+      <div class="remote-config">
+        <div class="form-group inline">
+          <label for="remote-name">Remote</label>
+          <input
+            id="remote-name"
+            type="text"
+            bind:value={remoteName}
+            placeholder="origin"
+            disabled={isPublishing || isLoading}
+          />
+        </div>
+        <div class="form-group inline">
+          <label for="branch">Branch</label>
+          <input
+            id="branch"
+            type="text"
+            bind:value={branch}
+            placeholder="main"
+            disabled={isPublishing || isLoading}
+          />
+        </div>
+      </div>
+    {/if}
+  </div>
+
+  <!-- Error Display -->
+  {#if error}
+    <div class="error-message">
+      {error}
+    </div>
+  {/if}
+
+  <!-- Publish Button -->
+  <div class="actions">
+    <button
+      type="button"
+      onclick={publishCards}
+      disabled={isPublishing || isLoading || publishableCount === 0 || !repoPath}
+      class="btn-primary btn-publish"
+    >
+      {#if isPublishing}
+        Publishing...
+      {:else if publishableCount === 0}
+        No Cards to Publish
+      {:else}
+        Publish {publishableCount} Card{publishableCount !== 1 ? 's' : ''}
+      {/if}
+    </button>
+
+    <button
+      type="button"
+      onclick={loadStatus}
+      disabled={isPublishing || isLoading || !repoPath}
+      class="btn-secondary"
+    >
+      Refresh Status
+    </button>
+  </div>
+
+  <!-- Privacy Notice -->
+  <div class="privacy-notice">
+    <strong>Privacy Filter Active:</strong>
+    <ul>
+      <li>✅ BUSINESS cards → Published</li>
+      <li>✅ IDEAS cards → Published</li>
+      <li>🔒 PRIVATE cards → Stay local only</li>
+      <li>🔒 PERSONAL cards → Stay local only</li>
+    </ul>
+  </div>
+</div>
+
+<style>
+  .publish-island {
+    background: #ffffff;
+    border: 1px solid #e5e7eb;
+    border-radius: 8px;
+    padding: 24px;
+    margin: 16px 0;
+  }
+
+  .header {
+    margin-bottom: 24px;
+  }
+
+  .header h2 {
+    margin: 0 0 8px 0;
+    font-size: 20px;
+    font-weight: 600;
+    color: #111827;
+  }
+
+  .subtitle {
+    margin: 0;
+    font-size: 14px;
+    color: #6b7280;
+  }
+
+  .config-section,
+  .status-section,
+  .options-section {
+    margin-bottom: 24px;
+  }
+
+  .form-group {
+    margin-bottom: 16px;
+  }
+
+  .form-group label {
+    display: block;
+    margin-bottom: 8px;
+    font-size: 14px;
+    font-weight: 500;
+    color: #374151;
+  }
+
+  .form-group input[type='text'] {
+    width: 100%;
+    padding: 8px 12px;
+    border: 1px solid #d1d5db;
+    border-radius: 4px;
+    font-size: 14px;
+  }
+
+  .form-group input[type='text']:disabled {
+    background: #f3f4f6;
+    cursor: not-allowed;
+  }
+
+  .input-with-button {
+    display: flex;
+    gap: 8px;
+  }
+
+  .input-with-button input {
+    flex: 1;
+  }
+
+  .status-grid {
+    display: grid;
+    grid-template-columns: repeat(auto-fit, minmax(150px, 1fr));
+    gap: 16px;
+  }
+
+  .status-item {
+    display: flex;
+    flex-direction: column;
+    gap: 4px;
+  }
+
+  .status-label {
+    font-size: 12px;
+    color: #6b7280;
+    text-transform: uppercase;
+    font-weight: 500;
+  }
+
+  .status-value {
+    font-size: 18px;
+    font-weight: 600;
+    color: #111827;
+  }
+
+  .checkbox-group {
+    margin-bottom: 16px;
+  }
+
+  .checkbox-group label {
+    display: flex;
+    align-items: center;
+    gap: 8px;
+    font-size: 14px;
+    color: #374151;
+    cursor: pointer;
+  }
+
+  .checkbox-group input[type='checkbox'] {
+    width: 16px;
+    height: 16px;
+    cursor: pointer;
+  }
+
+  .checkbox-group input[type='checkbox']:disabled {
+    cursor: not-allowed;
+  }
+
+  .remote-config {
+    display: flex;
+    gap: 16px;
+    margin-top: 12px;
+  }
+
+  .form-group.inline {
+    flex: 1;
+    margin-bottom: 0;
+  }
+
+  .form-group.inline input {
+    width: 100%;
+  }
+
+  .error-message {
+    background: #fef2f2;
+    border: 1px solid #fecaca;
+    color: #991b1b;
+    padding: 12px 16px;
+    border-radius: 4px;
+    margin-bottom: 16px;
+    font-size: 14px;
+  }
+
+  .actions {
+    display: flex;
+    gap: 12px;
+    margin-bottom: 24px;
+  }
+
+  .btn-primary,
+  .btn-secondary {
+    padding: 10px 20px;
+    border-radius: 4px;
+    font-size: 14px;
+    font-weight: 500;
+    cursor: pointer;
+    border: none;
+    transition: all 0.2s;
+  }
+
+  .btn-primary {
+    background: #2563eb;
+    color: white;
+    flex: 1;
+  }
+
+  .btn-primary:hover:not(:disabled) {
+    background: #1d4ed8;
+  }
+
+  .btn-primary:disabled {
+    background: #9ca3af;
+    cursor: not-allowed;
+  }
+
+  .btn-secondary {
+    background: #f3f4f6;
+    color: #374151;
+    border: 1px solid #d1d5db;
+  }
+
+  .btn-secondary:hover:not(:disabled) {
+    background: #e5e7eb;
+  }
+
+  .btn-secondary:disabled {
+    opacity: 0.5;
+    cursor: not-allowed;
+  }
+
+  .privacy-notice {
+    background: #f0f9ff;
+    border: 1px solid #bfdbfe;
+    border-radius: 4px;
+    padding: 16px;
+  }
+
+  .privacy-notice strong {
+    display: block;
+    margin-bottom: 8px;
+    color: #1e40af;
+    font-size: 14px;
+  }
+
+  .privacy-notice ul {
+    margin: 0;
+    padding-left: 20px;
+    list-style: none;
+  }
+
+  .privacy-notice li {
+    font-size: 13px;
+    color: #1e40af;
+    margin-bottom: 4px;
+  }
+
+  .privacy-notice li:last-child {
+    margin-bottom: 0;
+  }
+</style>


### PR DESCRIPTION
## ZETA Agent: Git Publish with Privacy Filtering

**Issue**: Closes #52  
**Module**: Writer  
**Duration**: 3 hours  
**Dependencies**: GAMMA #50 ✅, ETA #36 ✅

### Implementation

- ✅ Publish button in Writer UI
- ✅ Privacy filter (BUSINESS + IDEAS only, never PRIVATE/PERSONAL)
- ✅ libgit2-rs selective commit
- ✅ GitHub remote push
- ✅ UI feedback (success/error states)

### Files Changed

See commit log for details.

### Testing

- [ ] Manual: Create cards with different privacy levels
- [ ] Verify PRIVATE cards excluded from publish
- [ ] Verify BUSINESS + IDEAS cards included
- [ ] Test GitHub push authentication

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Co-Authored-By: Claude <noreply@anthropic.com>