### PR TITLE
Research Enhancement: OMEGA-2 - Research Exports

### DIFF
--- a/research/backend/api/__init__.py
+++ b/research/backend/api/__init__.py
@@ -1,0 +1,9 @@
+"""
+API Module
+
+Provides API routes and utilities for the research backend.
+"""
+
+from .routes import export_router
+
+__all__ = ['export_router']

--- a/research/backend/api/routes/__init__.py
+++ b/research/backend/api/routes/__init__.py
@@ -1,0 +1,9 @@
+"""
+API Routes Module
+
+Contains all API route definitions.
+"""
+
+from .export import router as export_router
+
+__all__ = ['export_router']

--- a/research/backend/api/routes/export.py
+++ b/research/backend/api/routes/export.py
@@ -1,0 +1,360 @@
+"""
+Export API Routes
+
+Provides endpoints for exporting research corpus to various formats:
+- BibTeX (.bib)
+- CSV (.csv)
+- JSON (.json)
+- EndNote (.enw)
+- RIS (.ris)
+"""
+
+import logging
+from typing import Optional, List
+from uuid import UUID
+
+from fastapi import APIRouter, HTTPException, Query, status
+from fastapi.responses import Response
+from pydantic import BaseModel, Field
+
+from ...db import get_db_manager
+from ...export import BibTeXExporter, CSVExporter, JSONExporter, EndNoteExporter
+
+logger = logging.getLogger(__name__)
+
+router = APIRouter(prefix="/api/export", tags=["Export"])
+
+
+# ============================================================================
+# Request/Response Models
+# ============================================================================
+
+class ExportRequest(BaseModel):
+    """Request model for export operations"""
+    platform: Optional[str] = Field(None, description="Filter by platform (twitter, youtube, reddit, web)")
+    limit: Optional[int] = Field(None, ge=1, le=10000, description="Maximum number of records to export")
+    source_ids: Optional[List[str]] = Field(None, description="Specific source IDs to export")
+
+
+class ExportInfoResponse(BaseModel):
+    """Response model for export format information"""
+    format: str = Field(..., description="Export format name")
+    extension: str = Field(..., description="File extension")
+    content_type: str = Field(..., description="MIME content type")
+    description: str = Field(..., description="Format description")
+    endpoint: str = Field(..., description="API endpoint URL")
+
+
+# ============================================================================
+# Export Endpoints
+# ============================================================================
+
+@router.get("/formats", response_model=List[ExportInfoResponse])
+async def list_export_formats():
+    """
+    List available export formats
+
+    Returns information about all supported export formats including
+    file extensions, content types, and endpoint URLs.
+    """
+    formats = [
+        {
+            "format": "BibTeX",
+            "extension": ".bib",
+            "content_type": "application/x-bibtex",
+            "description": "Academic citation format for LaTeX and reference managers",
+            "endpoint": "/api/export/bibtex",
+        },
+        {
+            "format": "CSV",
+            "extension": ".csv",
+            "content_type": "text/csv",
+            "description": "Comma-separated values for spreadsheet applications",
+            "endpoint": "/api/export/csv",
+        },
+        {
+            "format": "JSON",
+            "extension": ".json",
+            "content_type": "application/json",
+            "description": "Structured data format with full metadata",
+            "endpoint": "/api/export/json",
+        },
+        {
+            "format": "EndNote",
+            "extension": ".enw",
+            "content_type": "application/x-endnote-refer",
+            "description": "EndNote reference manager format",
+            "endpoint": "/api/export/endnote",
+        },
+        {
+            "format": "RIS",
+            "extension": ".ris",
+            "content_type": "application/x-research-info-systems",
+            "description": "Research Information Systems format (alternative EndNote)",
+            "endpoint": "/api/export/ris",
+        },
+    ]
+
+    return formats
+
+
+@router.get("/bibtex")
+async def export_bibtex(
+    platform: Optional[str] = Query(None, description="Filter by platform"),
+    limit: Optional[int] = Query(None, ge=1, le=10000, description="Maximum records"),
+):
+    """
+    Export corpus to BibTeX format
+
+    BibTeX is a reference management format commonly used with LaTeX.
+    Each source is exported as a BibTeX entry with appropriate fields
+    for citation management.
+
+    Query Parameters:
+    - **platform**: Filter by platform (twitter, youtube, reddit, web)
+    - **limit**: Maximum number of records to export
+    """
+    logger.info(f"BibTeX export requested: platform={platform}, limit={limit}")
+
+    try:
+        db_manager = get_db_manager()
+        exporter = BibTeXExporter(db_manager)
+
+        # Perform export
+        content = await exporter.export(platform=platform, limit=limit)
+
+        # Return as file download
+        return Response(
+            content=content,
+            media_type=exporter.get_content_type(),
+            headers={
+                "Content-Disposition": f'attachment; filename="corpus_export.{exporter.get_file_extension()}"'
+            }
+        )
+
+    except Exception as e:
+        logger.error(f"BibTeX export failed: {e}", exc_info=True)
+        raise HTTPException(
+            status_code=status.HTTP_500_INTERNAL_SERVER_ERROR,
+            detail=f"Export failed: {str(e)}"
+        )
+
+
+@router.get("/csv")
+async def export_csv(
+    platform: Optional[str] = Query(None, description="Filter by platform"),
+    limit: Optional[int] = Query(None, ge=1, le=10000, description="Maximum records"),
+    detailed: bool = Query(False, description="Export detailed format (one row per content)"),
+):
+    """
+    Export corpus to CSV format
+
+    CSV format provides tabular data suitable for spreadsheet applications
+    and data analysis tools. By default, exports one row per source with
+    aggregated content data. Use detailed=true for one row per content.
+
+    Query Parameters:
+    - **platform**: Filter by platform (twitter, youtube, reddit, web)
+    - **limit**: Maximum number of records to export
+    - **detailed**: Export detailed format with one row per content item
+    """
+    logger.info(f"CSV export requested: platform={platform}, limit={limit}, detailed={detailed}")
+
+    try:
+        db_manager = get_db_manager()
+        exporter = CSVExporter(db_manager)
+
+        # Perform export
+        if detailed:
+            content = await exporter.export_detailed(platform=platform, limit=limit)
+        else:
+            content = await exporter.export(platform=platform, limit=limit)
+
+        # Return as file download
+        filename = "corpus_export_detailed.csv" if detailed else "corpus_export.csv"
+        return Response(
+            content=content,
+            media_type=exporter.get_content_type(),
+            headers={
+                "Content-Disposition": f'attachment; filename="{filename}"'
+            }
+        )
+
+    except Exception as e:
+        logger.error(f"CSV export failed: {e}", exc_info=True)
+        raise HTTPException(
+            status_code=status.HTTP_500_INTERNAL_SERVER_ERROR,
+            detail=f"Export failed: {str(e)}"
+        )
+
+
+@router.get("/json")
+async def export_json(
+    platform: Optional[str] = Query(None, description="Filter by platform"),
+    limit: Optional[int] = Query(None, ge=1, le=10000, description="Maximum records"),
+    pretty: bool = Query(True, description="Pretty-print JSON"),
+    compact: bool = Query(False, description="Export compact format"),
+):
+    """
+    Export corpus to JSON format
+
+    JSON format provides structured data with full metadata and content.
+    By default, exports complete data structure. Use compact=true for
+    minimal structure with essential fields only.
+
+    Query Parameters:
+    - **platform**: Filter by platform (twitter, youtube, reddit, web)
+    - **limit**: Maximum number of records to export
+    - **pretty**: Pretty-print JSON with indentation
+    - **compact**: Export compact format (minimal structure)
+    """
+    logger.info(f"JSON export requested: platform={platform}, limit={limit}, pretty={pretty}, compact={compact}")
+
+    try:
+        db_manager = get_db_manager()
+        exporter = JSONExporter(db_manager)
+
+        # Perform export
+        if compact:
+            content = await exporter.export_compact(platform=platform, limit=limit)
+        else:
+            content = await exporter.export(platform=platform, limit=limit, pretty=pretty)
+
+        # Return as file download
+        filename = "corpus_export_compact.json" if compact else "corpus_export.json"
+        return Response(
+            content=content,
+            media_type=exporter.get_content_type(),
+            headers={
+                "Content-Disposition": f'attachment; filename="{filename}"'
+            }
+        )
+
+    except Exception as e:
+        logger.error(f"JSON export failed: {e}", exc_info=True)
+        raise HTTPException(
+            status_code=status.HTTP_500_INTERNAL_SERVER_ERROR,
+            detail=f"Export failed: {str(e)}"
+        )
+
+
+@router.get("/endnote")
+async def export_endnote(
+    platform: Optional[str] = Query(None, description="Filter by platform"),
+    limit: Optional[int] = Query(None, ge=1, le=10000, description="Maximum records"),
+):
+    """
+    Export corpus to EndNote format
+
+    EndNote format (.enw) is compatible with EndNote reference manager
+    and other citation management tools. Each source is exported with
+    appropriate reference type and fields.
+
+    Query Parameters:
+    - **platform**: Filter by platform (twitter, youtube, reddit, web)
+    - **limit**: Maximum number of records to export
+    """
+    logger.info(f"EndNote export requested: platform={platform}, limit={limit}")
+
+    try:
+        db_manager = get_db_manager()
+        exporter = EndNoteExporter(db_manager)
+
+        # Perform export
+        content = await exporter.export(platform=platform, limit=limit)
+
+        # Return as file download
+        return Response(
+            content=content,
+            media_type=exporter.get_content_type(),
+            headers={
+                "Content-Disposition": f'attachment; filename="corpus_export.{exporter.get_file_extension()}"'
+            }
+        )
+
+    except Exception as e:
+        logger.error(f"EndNote export failed: {e}", exc_info=True)
+        raise HTTPException(
+            status_code=status.HTTP_500_INTERNAL_SERVER_ERROR,
+            detail=f"Export failed: {str(e)}"
+        )
+
+
+@router.get("/ris")
+async def export_ris(
+    platform: Optional[str] = Query(None, description="Filter by platform"),
+    limit: Optional[int] = Query(None, ge=1, le=10000, description="Maximum records"),
+):
+    """
+    Export corpus to RIS format
+
+    RIS (Research Information Systems) format is an alternative reference
+    format compatible with EndNote, Zotero, Mendeley, and other reference
+    managers. Similar to EndNote but uses different tag format.
+
+    Query Parameters:
+    - **platform**: Filter by platform (twitter, youtube, reddit, web)
+    - **limit**: Maximum number of records to export
+    """
+    logger.info(f"RIS export requested: platform={platform}, limit={limit}")
+
+    try:
+        db_manager = get_db_manager()
+        exporter = EndNoteExporter(db_manager)
+
+        # Perform export (using RIS method)
+        content = await exporter.export_ris(platform=platform, limit=limit)
+
+        # Return as file download
+        return Response(
+            content=content,
+            media_type="application/x-research-info-systems",
+            headers={
+                "Content-Disposition": 'attachment; filename="corpus_export.ris"'
+            }
+        )
+
+    except Exception as e:
+        logger.error(f"RIS export failed: {e}", exc_info=True)
+        raise HTTPException(
+            status_code=status.HTTP_500_INTERNAL_SERVER_ERROR,
+            detail=f"Export failed: {str(e)}"
+        )
+
+
+@router.post("/bibtex", deprecated=True)
+async def export_bibtex_post(request: ExportRequest):
+    """
+    Export corpus to BibTeX format (POST method)
+
+    DEPRECATED: Use GET /api/export/bibtex with query parameters instead.
+    This endpoint will be removed in a future version.
+    """
+    logger.warning("Deprecated POST endpoint used: /api/export/bibtex")
+
+    source_ids = [UUID(sid) for sid in request.source_ids] if request.source_ids else None
+
+    try:
+        db_manager = get_db_manager()
+        exporter = BibTeXExporter(db_manager)
+
+        content = await exporter.export(
+            platform=request.platform,
+            limit=request.limit,
+            source_ids=source_ids
+        )
+
+        return Response(
+            content=content,
+            media_type=exporter.get_content_type(),
+            headers={
+                "Content-Disposition": f'attachment; filename="corpus_export.{exporter.get_file_extension()}"'
+            }
+        )
+
+    except Exception as e:
+        logger.error(f"BibTeX export failed: {e}", exc_info=True)
+        raise HTTPException(
+            status_code=status.HTTP_500_INTERNAL_SERVER_ERROR,
+            detail=f"Export failed: {str(e)}"
+        )

--- a/research/backend/export/__init__.py
+++ b/research/backend/export/__init__.py
@@ -1,0 +1,21 @@
+"""
+Export Module
+
+Provides export functionality for research corpus in multiple formats:
+- BibTeX: Academic citation format
+- CSV: Tabular data format
+- JSON: Raw structured data
+- EndNote: Reference manager format
+"""
+
+from .bibtex import BibTeXExporter
+from .csv import CSVExporter
+from .json import JSONExporter
+from .endnote import EndNoteExporter
+
+__all__ = [
+    'BibTeXExporter',
+    'CSVExporter',
+    'JSONExporter',
+    'EndNoteExporter',
+]

--- a/research/backend/export/base.py
+++ b/research/backend/export/base.py
@@ -1,0 +1,160 @@
+"""
+Base Exporter Class
+
+Provides shared functionality for all export formats.
+"""
+
+import logging
+from abc import ABC, abstractmethod
+from typing import List, Dict, Any, Optional
+from datetime import datetime
+from uuid import UUID
+
+from ..db import DatabaseManager, SourceCRUD, ContentCRUD
+
+logger = logging.getLogger(__name__)
+
+
+class BaseExporter(ABC):
+    """Base class for all exporters"""
+
+    def __init__(self, db_manager: DatabaseManager):
+        """
+        Initialize exporter
+
+        Args:
+            db_manager: Database manager instance
+        """
+        self.db = db_manager
+        self.source_crud = SourceCRUD(db_manager)
+        self.content_crud = ContentCRUD(db_manager)
+
+    async def fetch_corpus_data(
+        self,
+        platform: Optional[str] = None,
+        limit: Optional[int] = None,
+        source_ids: Optional[List[UUID]] = None
+    ) -> List[Dict[str, Any]]:
+        """
+        Fetch corpus data from database
+
+        Args:
+            platform: Filter by platform (twitter, youtube, reddit, web)
+            limit: Maximum number of records to fetch
+            source_ids: Specific source IDs to export
+
+        Returns:
+            List of records with source and content data
+        """
+        logger.info(f"Fetching corpus data: platform={platform}, limit={limit}")
+
+        # Build query based on filters
+        query_parts = []
+        params = []
+        param_idx = 1
+
+        query = """
+            SELECT
+                s.id as source_id,
+                s.platform,
+                s.url,
+                s.title,
+                s.author,
+                s.published_at,
+                s.scraped_at,
+                s.metadata as source_metadata,
+                c.id as content_id,
+                c.content_type,
+                c.text_content,
+                c.word_count,
+                c.language,
+                c.metadata as content_metadata,
+                c.created_at as content_created_at
+            FROM sources s
+            LEFT JOIN contents c ON s.id = c.source_id
+            WHERE 1=1
+        """
+
+        if platform:
+            query_parts.append(f"AND s.platform = ${param_idx}")
+            params.append(platform)
+            param_idx += 1
+
+        if source_ids:
+            placeholders = ','.join([f'${i}' for i in range(param_idx, param_idx + len(source_ids))])
+            query_parts.append(f"AND s.id IN ({placeholders})")
+            params.extend(source_ids)
+            param_idx += len(source_ids)
+
+        query += ' '.join(query_parts)
+        query += " ORDER BY s.scraped_at DESC, c.created_at DESC"
+
+        if limit:
+            query += f" LIMIT ${param_idx}"
+            params.append(limit)
+
+        rows = await self.db.fetch(query, *params)
+
+        # Convert to dict and group by source
+        records = {}
+        for row in rows:
+            source_id = str(row['source_id'])
+
+            if source_id not in records:
+                records[source_id] = {
+                    'source_id': source_id,
+                    'platform': row['platform'],
+                    'url': row['url'],
+                    'title': row['title'],
+                    'author': row['author'],
+                    'published_at': row['published_at'],
+                    'scraped_at': row['scraped_at'],
+                    'source_metadata': row['source_metadata'],
+                    'contents': []
+                }
+
+            # Add content if present
+            if row['content_id']:
+                records[source_id]['contents'].append({
+                    'content_id': str(row['content_id']),
+                    'content_type': row['content_type'],
+                    'text_content': row['text_content'],
+                    'word_count': row['word_count'],
+                    'language': row['language'],
+                    'content_metadata': row['content_metadata'],
+                    'created_at': row['content_created_at']
+                })
+
+        result = list(records.values())
+        logger.info(f"Fetched {len(result)} sources with content")
+        return result
+
+    @abstractmethod
+    async def export(
+        self,
+        platform: Optional[str] = None,
+        limit: Optional[int] = None,
+        source_ids: Optional[List[UUID]] = None
+    ) -> str:
+        """
+        Export corpus data to specific format
+
+        Args:
+            platform: Filter by platform
+            limit: Maximum number of records
+            source_ids: Specific source IDs to export
+
+        Returns:
+            Formatted export string
+        """
+        pass
+
+    @abstractmethod
+    def get_content_type(self) -> str:
+        """Return the MIME content type for this export format"""
+        pass
+
+    @abstractmethod
+    def get_file_extension(self) -> str:
+        """Return the file extension for this export format"""
+        pass

--- a/research/backend/export/bibtex.py
+++ b/research/backend/export/bibtex.py
@@ -1,0 +1,208 @@
+"""
+BibTeX Exporter
+
+Exports research corpus to BibTeX format for academic citation management.
+Supports various entry types based on content platform.
+"""
+
+import logging
+import re
+from typing import Optional, List, Dict, Any
+from datetime import datetime
+from uuid import UUID
+
+from .base import BaseExporter
+
+logger = logging.getLogger(__name__)
+
+
+class BibTeXExporter(BaseExporter):
+    """Export corpus to BibTeX format"""
+
+    # Platform to BibTeX entry type mapping
+    PLATFORM_ENTRY_TYPES = {
+        'twitter': 'misc',
+        'youtube': 'misc',
+        'reddit': 'misc',
+        'web': 'online',
+    }
+
+    def get_content_type(self) -> str:
+        """Return MIME type for BibTeX"""
+        return 'application/x-bibtex'
+
+    def get_file_extension(self) -> str:
+        """Return file extension for BibTeX"""
+        return 'bib'
+
+    def _sanitize_cite_key(self, text: str) -> str:
+        """
+        Create valid BibTeX citation key from text
+
+        Args:
+            text: Input text
+
+        Returns:
+            Sanitized citation key
+        """
+        # Remove special characters, keep alphanumeric and underscores
+        key = re.sub(r'[^a-zA-Z0-9_]', '', text.replace(' ', '_'))
+        return key[:50]  # Limit length
+
+    def _escape_bibtex(self, text: str) -> str:
+        """
+        Escape special BibTeX characters
+
+        Args:
+            text: Input text
+
+        Returns:
+            Escaped text safe for BibTeX
+        """
+        if not text:
+            return ''
+
+        # Escape special LaTeX/BibTeX characters
+        replacements = {
+            '&': r'\&',
+            '%': r'\%',
+            '$': r'\$',
+            '#': r'\#',
+            '_': r'\_',
+            '{': r'\{',
+            '}': r'\}',
+            '~': r'\textasciitilde{}',
+            '^': r'\textasciicircum{}',
+            '\\': r'\textbackslash{}',
+        }
+
+        for char, escaped in replacements.items():
+            text = text.replace(char, escaped)
+
+        return text
+
+    def _format_entry(self, record: Dict[str, Any], index: int) -> str:
+        """
+        Format single record as BibTeX entry
+
+        Args:
+            record: Source record with content
+            index: Record index for unique citation key
+
+        Returns:
+            BibTeX entry string
+        """
+        platform = record['platform']
+        entry_type = self.PLATFORM_ENTRY_TYPES.get(platform, 'misc')
+
+        # Generate citation key
+        author_key = self._sanitize_cite_key(record.get('author', 'unknown'))
+        title_key = self._sanitize_cite_key(record.get('title', 'untitled'))
+        year = ''
+        if record.get('published_at'):
+            year = record['published_at'].strftime('%Y')
+        cite_key = f"{author_key}_{title_key}_{year or index}"
+
+        # Build entry fields
+        fields = []
+
+        # Title (required for most types)
+        if record.get('title'):
+            title = self._escape_bibtex(record['title'])
+            fields.append(f"  title = {{{title}}}")
+
+        # Author
+        if record.get('author'):
+            author = self._escape_bibtex(record['author'])
+            fields.append(f"  author = {{{author}}}")
+
+        # Year
+        if record.get('published_at'):
+            year = record['published_at'].strftime('%Y')
+            fields.append(f"  year = {{{year}}}")
+
+        # URL (always present)
+        url = self._escape_bibtex(record['url'])
+        fields.append(f"  url = {{{url}}}")
+
+        # Note with platform and metadata
+        note_parts = [f"Platform: {platform}"]
+
+        # Add word count if available
+        total_words = sum(c.get('word_count', 0) for c in record.get('contents', []))
+        if total_words > 0:
+            note_parts.append(f"Word count: {total_words}")
+
+        # Add scraped date
+        if record.get('scraped_at'):
+            scraped = record['scraped_at'].strftime('%Y-%m-%d')
+            note_parts.append(f"Scraped: {scraped}")
+
+        fields.append(f"  note = {{{', '.join(note_parts)}}}")
+
+        # Accessed date (when scraped)
+        if record.get('scraped_at'):
+            urldate = record['scraped_at'].strftime('%Y-%m-%d')
+            fields.append(f"  urldate = {{{urldate}}}")
+
+        # Abstract (use first content text)
+        if record.get('contents'):
+            first_content = record['contents'][0]['text_content']
+            # Truncate to reasonable length
+            abstract = first_content[:500]
+            if len(first_content) > 500:
+                abstract += '...'
+            abstract = self._escape_bibtex(abstract)
+            fields.append(f"  abstract = {{{abstract}}}")
+
+        # Build entry
+        entry = f"@{entry_type}{{{cite_key},\n"
+        entry += ',\n'.join(fields)
+        entry += '\n}\n'
+
+        return entry
+
+    async def export(
+        self,
+        platform: Optional[str] = None,
+        limit: Optional[int] = None,
+        source_ids: Optional[List[UUID]] = None
+    ) -> str:
+        """
+        Export corpus to BibTeX format
+
+        Args:
+            platform: Filter by platform
+            limit: Maximum number of records
+            source_ids: Specific source IDs
+
+        Returns:
+            BibTeX formatted string
+        """
+        logger.info(f"Starting BibTeX export: platform={platform}, limit={limit}")
+
+        # Fetch data
+        records = await self.fetch_corpus_data(platform, limit, source_ids)
+
+        if not records:
+            logger.warning("No records found for export")
+            return "% No records found\n"
+
+        # Build BibTeX output
+        output = []
+        output.append("% BibTeX Export - Extrophi Research Corpus")
+        output.append(f"% Generated: {datetime.utcnow().strftime('%Y-%m-%d %H:%M:%S UTC')}")
+        output.append(f"% Total entries: {len(records)}")
+        if platform:
+            output.append(f"% Platform filter: {platform}")
+        output.append("")
+
+        # Format each entry
+        for idx, record in enumerate(records, 1):
+            entry = self._format_entry(record, idx)
+            output.append(entry)
+
+        result = '\n'.join(output)
+        logger.info(f"BibTeX export completed: {len(records)} entries, {len(result)} bytes")
+
+        return result

--- a/research/backend/export/csv.py
+++ b/research/backend/export/csv.py
@@ -1,0 +1,227 @@
+"""
+CSV Exporter
+
+Exports research corpus to CSV format for tabular data analysis.
+Each row represents a source with aggregated content data.
+"""
+
+import logging
+import csv
+import io
+from typing import Optional, List, Dict, Any
+from datetime import datetime
+from uuid import UUID
+
+from .base import BaseExporter
+
+logger = logging.getLogger(__name__)
+
+
+class CSVExporter(BaseExporter):
+    """Export corpus to CSV format"""
+
+    # CSV column headers
+    HEADERS = [
+        'source_id',
+        'platform',
+        'url',
+        'title',
+        'author',
+        'published_at',
+        'scraped_at',
+        'content_count',
+        'total_word_count',
+        'languages',
+        'content_types',
+        'text_preview',
+    ]
+
+    def get_content_type(self) -> str:
+        """Return MIME type for CSV"""
+        return 'text/csv'
+
+    def get_file_extension(self) -> str:
+        """Return file extension for CSV"""
+        return 'csv'
+
+    def _format_row(self, record: Dict[str, Any]) -> Dict[str, Any]:
+        """
+        Format single record as CSV row
+
+        Args:
+            record: Source record with content
+
+        Returns:
+            Dictionary with CSV column values
+        """
+        contents = record.get('contents', [])
+
+        # Aggregate content data
+        content_count = len(contents)
+        total_word_count = sum(c.get('word_count', 0) for c in contents)
+        languages = list(set(c.get('language', 'en') for c in contents))
+        content_types = list(set(c.get('content_type', '') for c in contents))
+
+        # Get text preview (first 200 chars of first content)
+        text_preview = ''
+        if contents:
+            first_text = contents[0].get('text_content', '')
+            text_preview = first_text[:200].replace('\n', ' ').replace('\r', ' ')
+            if len(first_text) > 200:
+                text_preview += '...'
+
+        # Format dates
+        published_at = ''
+        if record.get('published_at'):
+            published_at = record['published_at'].isoformat()
+
+        scraped_at = ''
+        if record.get('scraped_at'):
+            scraped_at = record['scraped_at'].isoformat()
+
+        return {
+            'source_id': record['source_id'],
+            'platform': record['platform'],
+            'url': record['url'],
+            'title': record.get('title', ''),
+            'author': record.get('author', ''),
+            'published_at': published_at,
+            'scraped_at': scraped_at,
+            'content_count': content_count,
+            'total_word_count': total_word_count,
+            'languages': ', '.join(languages),
+            'content_types': ', '.join(content_types),
+            'text_preview': text_preview,
+        }
+
+    async def export(
+        self,
+        platform: Optional[str] = None,
+        limit: Optional[int] = None,
+        source_ids: Optional[List[UUID]] = None
+    ) -> str:
+        """
+        Export corpus to CSV format
+
+        Args:
+            platform: Filter by platform
+            limit: Maximum number of records
+            source_ids: Specific source IDs
+
+        Returns:
+            CSV formatted string
+        """
+        logger.info(f"Starting CSV export: platform={platform}, limit={limit}")
+
+        # Fetch data
+        records = await self.fetch_corpus_data(platform, limit, source_ids)
+
+        if not records:
+            logger.warning("No records found for export")
+            # Return empty CSV with headers
+            output = io.StringIO()
+            writer = csv.DictWriter(output, fieldnames=self.HEADERS)
+            writer.writeheader()
+            return output.getvalue()
+
+        # Build CSV output
+        output = io.StringIO()
+        writer = csv.DictWriter(output, fieldnames=self.HEADERS)
+
+        # Write header
+        writer.writeheader()
+
+        # Write data rows
+        for record in records:
+            row = self._format_row(record)
+            writer.writerow(row)
+
+        result = output.getvalue()
+        logger.info(f"CSV export completed: {len(records)} rows, {len(result)} bytes")
+
+        return result
+
+    async def export_detailed(
+        self,
+        platform: Optional[str] = None,
+        limit: Optional[int] = None,
+        source_ids: Optional[List[UUID]] = None
+    ) -> str:
+        """
+        Export corpus to detailed CSV format (one row per content)
+
+        Args:
+            platform: Filter by platform
+            limit: Maximum number of records
+            source_ids: Specific source IDs
+
+        Returns:
+            CSV formatted string with detailed content rows
+        """
+        logger.info(f"Starting detailed CSV export: platform={platform}, limit={limit}")
+
+        # Fetch data
+        records = await self.fetch_corpus_data(platform, limit, source_ids)
+
+        if not records:
+            logger.warning("No records found for export")
+            return ''
+
+        # Detailed headers
+        headers = [
+            'source_id',
+            'platform',
+            'url',
+            'title',
+            'author',
+            'published_at',
+            'scraped_at',
+            'content_id',
+            'content_type',
+            'text_content',
+            'word_count',
+            'language',
+        ]
+
+        # Build CSV output
+        output = io.StringIO()
+        writer = csv.DictWriter(output, fieldnames=headers)
+
+        # Write header
+        writer.writeheader()
+
+        # Write data rows (one per content)
+        row_count = 0
+        for record in records:
+            source_data = {
+                'source_id': record['source_id'],
+                'platform': record['platform'],
+                'url': record['url'],
+                'title': record.get('title', ''),
+                'author': record.get('author', ''),
+                'published_at': record['published_at'].isoformat() if record.get('published_at') else '',
+                'scraped_at': record['scraped_at'].isoformat() if record.get('scraped_at') else '',
+            }
+
+            contents = record.get('contents', [])
+            if not contents:
+                # Write source row without content
+                writer.writerow({**source_data, 'content_id': '', 'content_type': '', 'text_content': '', 'word_count': '', 'language': ''})
+                row_count += 1
+            else:
+                # Write one row per content
+                for content in contents:
+                    writer.writerow({
+                        **source_data,
+                        'content_id': content['content_id'],
+                        'content_type': content['content_type'],
+                        'text_content': content['text_content'],
+                        'word_count': content.get('word_count', ''),
+                        'language': content.get('language', ''),
+                    })
+                    row_count += 1
+
+        result = output.getvalue()
+        logger.info(f"Detailed CSV export completed: {row_count} rows, {len(result)} bytes")
+
+        return result

--- a/research/backend/export/endnote.py
+++ b/research/backend/export/endnote.py
@@ -1,0 +1,284 @@
+"""
+EndNote Exporter
+
+Exports research corpus to EndNote format (.enw) for reference management.
+Uses RIS-like tagged format compatible with EndNote and other reference managers.
+"""
+
+import logging
+from typing import Optional, List, Dict, Any
+from datetime import datetime
+from uuid import UUID
+
+from .base import BaseExporter
+
+logger = logging.getLogger(__name__)
+
+
+class EndNoteExporter(BaseExporter):
+    """Export corpus to EndNote format"""
+
+    # Platform to EndNote reference type mapping
+    PLATFORM_REFERENCE_TYPES = {
+        'twitter': 'ELEC',  # Electronic source
+        'youtube': 'VIDEO',  # Video recording
+        'reddit': 'ELEC',   # Electronic source
+        'web': 'ELEC',      # Electronic source
+    }
+
+    def get_content_type(self) -> str:
+        """Return MIME type for EndNote"""
+        return 'application/x-endnote-refer'
+
+    def get_file_extension(self) -> str:
+        """Return file extension for EndNote"""
+        return 'enw'
+
+    def _format_entry(self, record: Dict[str, Any]) -> str:
+        """
+        Format single record as EndNote entry
+
+        EndNote format uses tags:
+        %0 = Reference Type
+        %A = Author
+        %T = Title
+        %D = Year
+        %U = URL
+        %N = Notes
+        %K = Keywords
+        %X = Abstract
+        %M = Access Date
+
+        Args:
+            record: Source record with content
+
+        Returns:
+            EndNote formatted entry
+        """
+        lines = []
+        platform = record['platform']
+
+        # Reference type
+        ref_type = self.PLATFORM_REFERENCE_TYPES.get(platform, 'ELEC')
+        lines.append(f"%0 {ref_type}")
+
+        # Author
+        if record.get('author'):
+            lines.append(f"%A {record['author']}")
+
+        # Title
+        if record.get('title'):
+            lines.append(f"%T {record['title']}")
+        else:
+            # Use platform and URL if no title
+            lines.append(f"%T {platform.title()} content from {record['url'][:50]}")
+
+        # Year
+        if record.get('published_at'):
+            year = record['published_at'].strftime('%Y')
+            lines.append(f"%D {year}")
+
+        # Date (full)
+        if record.get('published_at'):
+            date = record['published_at'].strftime('%Y/%m/%d')
+            lines.append(f"%8 {date}")
+
+        # URL
+        lines.append(f"%U {record['url']}")
+
+        # Keywords (platform and metadata)
+        keywords = [platform]
+        if record.get('source_metadata'):
+            metadata = record['source_metadata']
+            if isinstance(metadata, dict):
+                # Add relevant metadata as keywords
+                for key in ['tags', 'category', 'topic']:
+                    if key in metadata:
+                        value = metadata[key]
+                        if isinstance(value, list):
+                            keywords.extend(value)
+                        elif isinstance(value, str):
+                            keywords.append(value)
+
+        if keywords:
+            lines.append(f"%K {', '.join(keywords)}")
+
+        # Abstract (first content text)
+        if record.get('contents'):
+            first_content = record['contents'][0]['text_content']
+            # Truncate to reasonable length
+            abstract = first_content[:1000]
+            if len(first_content) > 1000:
+                abstract += '...'
+            # EndNote format: multi-line abstract
+            lines.append(f"%X {abstract}")
+
+        # Notes (word count, languages, scraped date)
+        notes = []
+        notes.append(f"Platform: {platform}")
+
+        total_words = sum(c.get('word_count', 0) for c in record.get('contents', []))
+        if total_words > 0:
+            notes.append(f"Word count: {total_words}")
+
+        languages = list(set(c.get('language', 'en') for c in record.get('contents', [])))
+        if languages:
+            notes.append(f"Languages: {', '.join(languages)}")
+
+        content_types = list(set(c.get('content_type', '') for c in record.get('contents', [])))
+        if content_types:
+            notes.append(f"Content types: {', '.join(content_types)}")
+
+        if notes:
+            lines.append(f"%N {'; '.join(notes)}")
+
+        # Access date (when scraped)
+        if record.get('scraped_at'):
+            access_date = record['scraped_at'].strftime('%Y/%m/%d')
+            lines.append(f"%M {access_date}")
+
+        # End of record marker
+        lines.append("")
+
+        return '\n'.join(lines)
+
+    async def export(
+        self,
+        platform: Optional[str] = None,
+        limit: Optional[int] = None,
+        source_ids: Optional[List[UUID]] = None
+    ) -> str:
+        """
+        Export corpus to EndNote format
+
+        Args:
+            platform: Filter by platform
+            limit: Maximum number of records
+            source_ids: Specific source IDs
+
+        Returns:
+            EndNote formatted string
+        """
+        logger.info(f"Starting EndNote export: platform={platform}, limit={limit}")
+
+        # Fetch data
+        records = await self.fetch_corpus_data(platform, limit, source_ids)
+
+        if not records:
+            logger.warning("No records found for export")
+            return ""
+
+        # Build EndNote output
+        output = []
+
+        # Optional: Add header comment
+        output.append("% EndNote Export - Extrophi Research Corpus")
+        output.append(f"% Generated: {datetime.utcnow().strftime('%Y-%m-%d %H:%M:%S UTC')}")
+        output.append(f"% Total entries: {len(records)}")
+        if platform:
+            output.append(f"% Platform filter: {platform}")
+        output.append("")
+
+        # Format each entry
+        for record in records:
+            entry = self._format_entry(record)
+            output.append(entry)
+
+        result = '\n'.join(output)
+        logger.info(f"EndNote export completed: {len(records)} entries, {len(result)} bytes")
+
+        return result
+
+    async def export_ris(
+        self,
+        platform: Optional[str] = None,
+        limit: Optional[int] = None,
+        source_ids: Optional[List[UUID]] = None
+    ) -> str:
+        """
+        Export corpus to RIS format (alternative reference format)
+
+        RIS format uses different tags:
+        TY = Type of reference
+        AU = Author
+        TI = Title
+        PY = Year
+        UR = URL
+        AB = Abstract
+        KW = Keywords
+        ER = End of reference
+
+        Args:
+            platform: Filter by platform
+            limit: Maximum number of records
+            source_ids: Specific source IDs
+
+        Returns:
+            RIS formatted string
+        """
+        logger.info(f"Starting RIS export: platform={platform}, limit={limit}")
+
+        # Fetch data
+        records = await self.fetch_corpus_data(platform, limit, source_ids)
+
+        if not records:
+            logger.warning("No records found for export")
+            return ""
+
+        # RIS type mapping
+        RIS_TYPES = {
+            'twitter': 'ELEC',
+            'youtube': 'VIDEO',
+            'reddit': 'ELEC',
+            'web': 'ELEC',
+        }
+
+        output = []
+
+        for record in records:
+            platform = record['platform']
+
+            # Start entry
+            ris_type = RIS_TYPES.get(platform, 'ELEC')
+            output.append(f"TY  - {ris_type}")
+
+            # Author
+            if record.get('author'):
+                output.append(f"AU  - {record['author']}")
+
+            # Title
+            if record.get('title'):
+                output.append(f"TI  - {record['title']}")
+
+            # Year
+            if record.get('published_at'):
+                year = record['published_at'].strftime('%Y')
+                output.append(f"PY  - {year}")
+
+            # URL
+            output.append(f"UR  - {record['url']}")
+
+            # Abstract
+            if record.get('contents'):
+                first_content = record['contents'][0]['text_content']
+                abstract = first_content[:1000]
+                if len(first_content) > 1000:
+                    abstract += '...'
+                output.append(f"AB  - {abstract}")
+
+            # Keywords
+            output.append(f"KW  - {platform}")
+
+            # Access date
+            if record.get('scraped_at'):
+                access_date = record['scraped_at'].strftime('%Y/%m/%d')
+                output.append(f"Y2  - {access_date}")
+
+            # End of record
+            output.append("ER  -")
+            output.append("")
+
+        result = '\n'.join(output)
+        logger.info(f"RIS export completed: {len(records)} entries, {len(result)} bytes")
+
+        return result

--- a/research/backend/export/json.py
+++ b/research/backend/export/json.py
@@ -1,0 +1,195 @@
+"""
+JSON Exporter
+
+Exports research corpus to JSON format for structured data interchange.
+Provides complete source and content data with metadata.
+"""
+
+import logging
+import json
+from typing import Optional, List, Dict, Any
+from datetime import datetime
+from uuid import UUID
+
+from .base import BaseExporter
+
+logger = logging.getLogger(__name__)
+
+
+class JSONExporter(BaseExporter):
+    """Export corpus to JSON format"""
+
+    def get_content_type(self) -> str:
+        """Return MIME type for JSON"""
+        return 'application/json'
+
+    def get_file_extension(self) -> str:
+        """Return file extension for JSON"""
+        return 'json'
+
+    def _serialize_datetime(self, obj: Any) -> Any:
+        """
+        Serialize datetime objects to ISO format
+
+        Args:
+            obj: Object to serialize
+
+        Returns:
+            Serialized object
+        """
+        if isinstance(obj, datetime):
+            return obj.isoformat()
+        raise TypeError(f"Type {type(obj)} not serializable")
+
+    def _format_record(self, record: Dict[str, Any]) -> Dict[str, Any]:
+        """
+        Format single record for JSON export
+
+        Args:
+            record: Source record with content
+
+        Returns:
+            Formatted record dictionary
+        """
+        # Convert datetime objects to ISO strings
+        formatted = {
+            'source': {
+                'id': record['source_id'],
+                'platform': record['platform'],
+                'url': record['url'],
+                'title': record.get('title'),
+                'author': record.get('author'),
+                'published_at': record['published_at'].isoformat() if record.get('published_at') else None,
+                'scraped_at': record['scraped_at'].isoformat() if record.get('scraped_at') else None,
+                'metadata': record.get('source_metadata', {}),
+            },
+            'contents': []
+        }
+
+        # Add contents
+        for content in record.get('contents', []):
+            formatted['contents'].append({
+                'id': content['content_id'],
+                'type': content['content_type'],
+                'text': content['text_content'],
+                'word_count': content.get('word_count'),
+                'language': content.get('language', 'en'),
+                'created_at': content['created_at'].isoformat() if content.get('created_at') else None,
+                'metadata': content.get('content_metadata', {}),
+            })
+
+        # Add aggregated statistics
+        formatted['statistics'] = {
+            'content_count': len(formatted['contents']),
+            'total_word_count': sum(c.get('word_count', 0) for c in record.get('contents', [])),
+            'languages': list(set(c.get('language', 'en') for c in record.get('contents', []))),
+            'content_types': list(set(c.get('content_type', '') for c in record.get('contents', []))),
+        }
+
+        return formatted
+
+    async def export(
+        self,
+        platform: Optional[str] = None,
+        limit: Optional[int] = None,
+        source_ids: Optional[List[UUID]] = None,
+        pretty: bool = True
+    ) -> str:
+        """
+        Export corpus to JSON format
+
+        Args:
+            platform: Filter by platform
+            limit: Maximum number of records
+            source_ids: Specific source IDs
+            pretty: Pretty-print JSON with indentation
+
+        Returns:
+            JSON formatted string
+        """
+        logger.info(f"Starting JSON export: platform={platform}, limit={limit}, pretty={pretty}")
+
+        # Fetch data
+        records = await self.fetch_corpus_data(platform, limit, source_ids)
+
+        # Build export structure
+        export_data = {
+            'metadata': {
+                'exported_at': datetime.utcnow().isoformat(),
+                'source': 'Extrophi Research Corpus',
+                'version': '1.0.0',
+                'filters': {
+                    'platform': platform,
+                    'limit': limit,
+                },
+                'total_records': len(records),
+            },
+            'records': []
+        }
+
+        # Format each record
+        for record in records:
+            formatted = self._format_record(record)
+            export_data['records'].append(formatted)
+
+        # Add corpus statistics
+        export_data['corpus_statistics'] = {
+            'total_sources': len(records),
+            'total_contents': sum(len(r.get('contents', [])) for r in records),
+            'total_word_count': sum(
+                sum(c.get('word_count', 0) for c in r.get('contents', []))
+                for r in records
+            ),
+            'platforms': list(set(r['platform'] for r in records)),
+        }
+
+        # Serialize to JSON
+        if pretty:
+            result = json.dumps(export_data, indent=2, ensure_ascii=False)
+        else:
+            result = json.dumps(export_data, ensure_ascii=False)
+
+        logger.info(f"JSON export completed: {len(records)} records, {len(result)} bytes")
+
+        return result
+
+    async def export_compact(
+        self,
+        platform: Optional[str] = None,
+        limit: Optional[int] = None,
+        source_ids: Optional[List[UUID]] = None
+    ) -> str:
+        """
+        Export corpus to compact JSON format (minimal structure)
+
+        Args:
+            platform: Filter by platform
+            limit: Maximum number of records
+            source_ids: Specific source IDs
+
+        Returns:
+            Compact JSON formatted string
+        """
+        logger.info(f"Starting compact JSON export: platform={platform}, limit={limit}")
+
+        # Fetch data
+        records = await self.fetch_corpus_data(platform, limit, source_ids)
+
+        # Build compact structure (just the essential data)
+        compact_records = []
+        for record in records:
+            compact = {
+                'id': record['source_id'],
+                'platform': record['platform'],
+                'url': record['url'],
+                'title': record.get('title'),
+                'author': record.get('author'),
+                'date': record['published_at'].isoformat() if record.get('published_at') else None,
+                'content': ' '.join(c['text_content'] for c in record.get('contents', [])),
+            }
+            compact_records.append(compact)
+
+        result = json.dumps(compact_records, ensure_ascii=False)
+        logger.info(f"Compact JSON export completed: {len(records)} records, {len(result)} bytes")
+
+        return result

--- a/research/backend/main.py
+++ b/research/backend/main.py
@@ -21,6 +21,9 @@ from db import get_db_manager, ContentCRUD, SourceCRUD, ScrapeJobCRUD, VectorSea
 # Import enrichment engine
 from enrichment import EnrichmentEngine
 
+# Import API routes
+from api.routes import export_router
+
 # Load environment variables
 load_dotenv()
 
@@ -54,6 +57,9 @@ app.add_middleware(
     allow_methods=["*"],
     allow_headers=["*"],
 )
+
+# Include API routers
+app.include_router(export_router)
 
 
 # ============================================================================
@@ -314,6 +320,14 @@ async def root():
         "endpoints": {
             "enrich": "POST /api/enrich",
             "scrape": "POST /api/scrape",
+            "export": {
+                "formats": "GET /api/export/formats",
+                "bibtex": "GET /api/export/bibtex",
+                "csv": "GET /api/export/csv",
+                "json": "GET /api/export/json",
+                "endnote": "GET /api/export/endnote",
+                "ris": "GET /api/export/ris",
+            }
         }
     }
 

--- a/research/backend/tests/test_export.py
+++ b/research/backend/tests/test_export.py
@@ -1,0 +1,264 @@
+"""
+Tests for export functionality
+
+Tests all export formats: BibTeX, CSV, JSON, EndNote
+"""
+
+import pytest
+from uuid import uuid4
+from datetime import datetime
+
+from export.bibtex import BibTeXExporter
+from export.csv import CSVExporter
+from export.json import JSONExporter
+from export.endnote import EndNoteExporter
+
+
+@pytest.fixture
+def mock_records():
+    """Mock corpus records for testing"""
+    return [
+        {
+            'source_id': str(uuid4()),
+            'platform': 'twitter',
+            'url': 'https://twitter.com/example/status/123',
+            'title': 'Test Tweet',
+            'author': 'Test Author',
+            'published_at': datetime(2024, 1, 1, 12, 0, 0),
+            'scraped_at': datetime(2024, 1, 2, 12, 0, 0),
+            'source_metadata': {'likes': 100, 'retweets': 50},
+            'contents': [
+                {
+                    'content_id': str(uuid4()),
+                    'content_type': 'post',
+                    'text_content': 'This is a test tweet content.',
+                    'word_count': 6,
+                    'language': 'en',
+                    'content_metadata': {},
+                    'created_at': datetime(2024, 1, 2, 12, 0, 0),
+                }
+            ]
+        },
+        {
+            'source_id': str(uuid4()),
+            'platform': 'youtube',
+            'url': 'https://youtube.com/watch?v=test123',
+            'title': 'Test Video',
+            'author': 'Test Channel',
+            'published_at': datetime(2024, 1, 3, 12, 0, 0),
+            'scraped_at': datetime(2024, 1, 4, 12, 0, 0),
+            'source_metadata': {'views': 1000, 'duration': 600},
+            'contents': [
+                {
+                    'content_id': str(uuid4()),
+                    'content_type': 'transcript',
+                    'text_content': 'This is a test video transcript. It has multiple sentences.',
+                    'word_count': 11,
+                    'language': 'en',
+                    'content_metadata': {},
+                    'created_at': datetime(2024, 1, 4, 12, 0, 0),
+                }
+            ]
+        }
+    ]
+
+
+class TestBibTeXExporter:
+    """Tests for BibTeX exporter"""
+
+    def test_sanitize_cite_key(self):
+        """Test citation key sanitization"""
+        exporter = BibTeXExporter(None)
+
+        # Test basic sanitization
+        assert exporter._sanitize_cite_key("Test Author") == "TestAuthor"
+        assert exporter._sanitize_cite_key("Test-Author@2024") == "TestAuthor2024"
+        assert exporter._sanitize_cite_key("Test & Author") == "TestAuthor"
+
+        # Test length limit
+        long_text = "a" * 100
+        assert len(exporter._sanitize_cite_key(long_text)) <= 50
+
+    def test_escape_bibtex(self):
+        """Test BibTeX character escaping"""
+        exporter = BibTeXExporter(None)
+
+        # Test special characters
+        assert exporter._escape_bibtex("Test & Author") == r"Test \& Author"
+        assert exporter._escape_bibtex("50% complete") == r"50\% complete"
+        assert exporter._escape_bibtex("$100 price") == r"\$100 price"
+        assert exporter._escape_bibtex("Test_title") == r"Test\_title"
+
+    def test_format_entry(self, mock_records):
+        """Test BibTeX entry formatting"""
+        exporter = BibTeXExporter(None)
+
+        entry = exporter._format_entry(mock_records[0], 1)
+
+        # Verify entry structure
+        assert entry.startswith("@misc{")
+        assert "title = {Test Tweet}" in entry
+        assert "author = {Test Author}" in entry
+        assert "year = {2024}" in entry
+        assert "url = {https://twitter.com/example/status/123}" in entry
+        assert "Platform: twitter" in entry
+
+    def test_get_content_type(self):
+        """Test content type"""
+        exporter = BibTeXExporter(None)
+        assert exporter.get_content_type() == 'application/x-bibtex'
+        assert exporter.get_file_extension() == 'bib'
+
+
+class TestCSVExporter:
+    """Tests for CSV exporter"""
+
+    def test_format_row(self, mock_records):
+        """Test CSV row formatting"""
+        exporter = CSVExporter(None)
+
+        row = exporter._format_row(mock_records[0])
+
+        # Verify row structure
+        assert row['source_id'] == mock_records[0]['source_id']
+        assert row['platform'] == 'twitter'
+        assert row['url'] == 'https://twitter.com/example/status/123'
+        assert row['title'] == 'Test Tweet'
+        assert row['author'] == 'Test Author'
+        assert row['content_count'] == 1
+        assert row['total_word_count'] == 6
+        assert 'en' in row['languages']
+        assert 'post' in row['content_types']
+        assert 'test tweet content' in row['text_preview'].lower()
+
+    def test_headers(self):
+        """Test CSV headers"""
+        exporter = CSVExporter(None)
+
+        expected_headers = [
+            'source_id', 'platform', 'url', 'title', 'author',
+            'published_at', 'scraped_at', 'content_count',
+            'total_word_count', 'languages', 'content_types', 'text_preview'
+        ]
+
+        assert exporter.HEADERS == expected_headers
+
+    def test_get_content_type(self):
+        """Test content type"""
+        exporter = CSVExporter(None)
+        assert exporter.get_content_type() == 'text/csv'
+        assert exporter.get_file_extension() == 'csv'
+
+
+class TestJSONExporter:
+    """Tests for JSON exporter"""
+
+    def test_format_record(self, mock_records):
+        """Test JSON record formatting"""
+        exporter = JSONExporter(None)
+
+        formatted = exporter._format_record(mock_records[0])
+
+        # Verify structure
+        assert 'source' in formatted
+        assert 'contents' in formatted
+        assert 'statistics' in formatted
+
+        # Verify source data
+        assert formatted['source']['platform'] == 'twitter'
+        assert formatted['source']['title'] == 'Test Tweet'
+        assert formatted['source']['author'] == 'Test Author'
+
+        # Verify contents
+        assert len(formatted['contents']) == 1
+        assert formatted['contents'][0]['type'] == 'post'
+        assert formatted['contents'][0]['word_count'] == 6
+
+        # Verify statistics
+        assert formatted['statistics']['content_count'] == 1
+        assert formatted['statistics']['total_word_count'] == 6
+
+    def test_serialize_datetime(self):
+        """Test datetime serialization"""
+        exporter = JSONExporter(None)
+
+        dt = datetime(2024, 1, 1, 12, 0, 0)
+        serialized = exporter._serialize_datetime(dt)
+        assert serialized == '2024-01-01T12:00:00'
+
+        # Test error for non-datetime
+        with pytest.raises(TypeError):
+            exporter._serialize_datetime("not a datetime")
+
+    def test_get_content_type(self):
+        """Test content type"""
+        exporter = JSONExporter(None)
+        assert exporter.get_content_type() == 'application/json'
+        assert exporter.get_file_extension() == 'json'
+
+
+class TestEndNoteExporter:
+    """Tests for EndNote exporter"""
+
+    def test_format_entry(self, mock_records):
+        """Test EndNote entry formatting"""
+        exporter = EndNoteExporter(None)
+
+        entry = exporter._format_entry(mock_records[0])
+
+        # Verify entry structure (EndNote format uses % tags)
+        assert '%0 ELEC' in entry  # Reference type
+        assert '%A Test Author' in entry  # Author
+        assert '%T Test Tweet' in entry  # Title
+        assert '%D 2024' in entry  # Year
+        assert '%U https://twitter.com/example/status/123' in entry  # URL
+        assert 'Platform: twitter' in entry  # Note
+
+    def test_platform_reference_types(self):
+        """Test platform to reference type mapping"""
+        exporter = EndNoteExporter(None)
+
+        assert exporter.PLATFORM_REFERENCE_TYPES['twitter'] == 'ELEC'
+        assert exporter.PLATFORM_REFERENCE_TYPES['youtube'] == 'VIDEO'
+        assert exporter.PLATFORM_REFERENCE_TYPES['reddit'] == 'ELEC'
+        assert exporter.PLATFORM_REFERENCE_TYPES['web'] == 'ELEC'
+
+    def test_get_content_type(self):
+        """Test content type"""
+        exporter = EndNoteExporter(None)
+        assert exporter.get_content_type() == 'application/x-endnote-refer'
+        assert exporter.get_file_extension() == 'enw'
+
+
+@pytest.mark.asyncio
+class TestExportIntegration:
+    """Integration tests for export functionality"""
+
+    async def test_export_with_no_data(self, db_manager):
+        """Test export with empty database"""
+        exporter = JSONExporter(db_manager)
+
+        # Should handle empty results gracefully
+        result = await exporter.export(platform='nonexistent')
+        assert 'total_records": 0' in result
+
+    async def test_export_with_platform_filter(self, db_manager, sample_data):
+        """Test export with platform filter"""
+        exporter = JSONExporter(db_manager)
+
+        # Export only twitter content
+        result = await exporter.export(platform='twitter', limit=10)
+        assert 'twitter' in result
+        # Should not contain other platforms if filter works
+        # (assuming sample_data has multiple platforms)
+
+    async def test_export_with_limit(self, db_manager, sample_data):
+        """Test export with limit"""
+        exporter = JSONExporter(db_manager)
+
+        # Export with small limit
+        result = await exporter.export(limit=1)
+        assert 'total_records": 1' in result
+
+
+# Run tests with: pytest research/backend/tests/test_export.py -v


### PR DESCRIPTION
## Summary

Implements research corpus export functionality for issue #84. Enables users to export their corpus data in multiple academic and data-friendly formats.

## Changes

### Export Formats Implemented:
- **BibTeX (.bib)** - Academic citation format for LaTeX and reference managers
- **CSV (.csv)** - Tabular data format for spreadsheet applications
- **JSON (.json)** - Structured data format with full metadata
- **EndNote (.enw)** - EndNote reference manager format  
- **RIS (.ris)** - Alternative reference format (compatible with Zotero, Mendeley)

### API Endpoints:
- `GET /api/export/formats` - List all available export formats
- `GET /api/export/bibtex` - Export to BibTeX format
- `GET /api/export/csv` - Export to CSV (with optional detailed mode)
- `GET /api/export/json` - Export to JSON (with optional compact mode)
- `GET /api/export/endnote` - Export to EndNote format
- `GET /api/export/ris` - Export to RIS format

### Features:
- Platform filtering (twitter, youtube, reddit, web)
- Configurable result limits for large datasets
- Multiple export variants:
  - Detailed CSV (one row per content item)
  - Compact JSON (minimal structure)
- Proper MIME types and file download headers
- Comprehensive unit tests

### Architecture:
- `export/base.py` - Base exporter class with shared data fetching logic
- `export/bibtex.py` - BibTeX format exporter with LaTeX escaping
- `export/csv.py` - CSV format exporter with aggregated and detailed modes
- `export/json.py` - JSON format exporter with full and compact modes
- `export/endnote.py` - EndNote/RIS format exporter
- `api/routes/export.py` - FastAPI routes with full documentation
- `tests/test_export.py` - Unit tests for all exporters

## Testing

Unit tests provided for:
- BibTeX citation key generation and escaping
- CSV row formatting and headers
- JSON serialization and structure
- EndNote entry formatting
- Integration tests for database queries

Run tests with:
```bash
cd research/backend
pytest tests/test_export.py -v
API Documentation
Full API documentation available at /docs when server is running:

cd research/backend
uvicorn main:app --reload
# Visit http://localhost:8000/docs
Example Usage
Export to BibTeX:
curl "http://localhost:8000/api/export/bibtex?platform=twitter&limit=10" -o corpus.bib
Export to detailed CSV:
curl "http://localhost:8000/api/export/csv?detailed=true" -o corpus.csv
Export to JSON:
curl "http://localhost:8000/api/export/json?pretty=true" -o corpus.json
Resolves
Closes #84

Dependencies
Requires PostgreSQL database with sources and contents tables
All Python dependencies already present in requirements.txt
Uses standard library modules (csv, json, re, io)
Duration
Completed in approximately 1 hour as estimated.